### PR TITLE
add support for native script inputs

### DIFF
--- a/packages/sidan-csl-rs/src/builder/core.rs
+++ b/packages/sidan-csl-rs/src/builder/core.rs
@@ -204,6 +204,7 @@ impl IMeshTxBuilderCore for MeshTxBuilderCore {
         for input in inputs {
             match input {
                 TxIn::PubKeyTxIn(pub_key_tx_in) => mesh_csl.add_tx_in(pub_key_tx_in)?,
+                TxIn::SimpleScriptTxIn(simple_script_tx_in) => mesh_csl.add_simple_script_tx_in(simple_script_tx_in)?,
                 TxIn::ScriptTxIn(script_tx_in) => mesh_csl.add_script_tx_in(script_tx_in)?,
             };
         }

--- a/packages/sidan-csl-rs/src/model/mod.rs
+++ b/packages/sidan-csl-rs/src/model/mod.rs
@@ -51,6 +51,7 @@ pub struct ValidityRange {
 #[serde(rename_all = "camelCase")]
 pub enum TxIn {
     PubKeyTxIn(PubKeyTxIn),
+    SimpleScriptTxIn(SimpleScriptTxIn),
     ScriptTxIn(ScriptTxIn),
 }
 
@@ -66,6 +67,35 @@ pub struct RefTxIn {
 pub struct PubKeyTxIn {
     pub type_: String,
     pub tx_in: TxInParameter,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimpleScriptTxIn {
+    pub type_: String,
+    pub tx_in: TxInParameter,
+    pub simple_script_tx_in: SimpleScriptTxInParameter,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SimpleScriptTxInParameter {
+    ProvidedSimpleScriptSource(ProvidedSimpleScriptSource),
+    InlineSimpleScriptSource(InlineSimpleScriptSource),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvidedSimpleScriptSource {
+    pub type_: String,
+    pub script_cbor: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineSimpleScriptSource {
+    pub type_: String,
+    pub ref_tx_in: RefTxIn,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/packages/whisky/src/builder/interface.rs
+++ b/packages/whisky/src/builder/interface.rs
@@ -140,12 +140,12 @@ pub trait IMeshTxBuilder {
     /// ### Arguments
     ///
     /// * `script_cbor` - The script in CBOR format
-    /// * `version` - The language version
+    /// * `version` - The language version, leave as None for Native scripts
     ///
     /// ### Returns
     ///
     /// * `Self` - The MeshTxBuilder instance
-    fn tx_in_script(&mut self, script_cbor: &str, version: LanguageVersion) -> &mut Self;
+    fn tx_in_script(&mut self, script_cbor: &str, version: Option<LanguageVersion>) -> &mut Self;
 
     /// ## Transaction building method
     ///

--- a/packages/whisky/tests/mesh_tx_builder.rs
+++ b/packages/whisky/tests/mesh_tx_builder.rs
@@ -161,7 +161,7 @@ mod mesh_tx_builder_core_tests {
                 vec![asset],
                 "addr_test1vr3vljjxan0hl6u28fle2l4ds6ugc9t08lwevpauk38t3agx7rtq6",
             )
-            .tx_in_script(script_cbor, LanguageVersion::V2)
+            .tx_in_script(script_cbor, Some(LanguageVersion::V2))
             .tx_in_datum_value(&data)
             .spending_reference_tx_in_redeemer_value(Redeemer {
                 data: data.clone(),


### PR DESCRIPTION
BREAKING CHANGE:

When adding script inputs, the Language Version is now an Option, leaving it as None represents native scripts.