### PR TITLE
Fix/min output with info

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -2830,7 +2830,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidan-csl-rs"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cardano-serialization-lib 13.2.0",
  "cryptoxide",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "whisky"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cryptoxide",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "whisky-examples"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-version = "0.9.13"
+version = "0.9.14"
 resolver = "2"
 members = [
     "sidan-csl-rs",

--- a/packages/sidan-csl-rs/Cargo.toml
+++ b/packages/sidan-csl-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidan-csl-rs"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wrapper around the cardano-serialization-lib for easier transaction building, heavily inspired by cardano-cli APIs"

--- a/packages/sidan-csl-rs/src/core/core_csl.rs
+++ b/packages/sidan-csl-rs/src/core/core_csl.rs
@@ -199,10 +199,20 @@ impl MeshCSL {
         match built_output.amount().multiasset() {
             Some(multiasset) => {
                 if multiasset.len() == 0 {
-                    built_output = csl::TransactionOutput::new(
+                    let mut new_built_output = csl::TransactionOutput::new(
                         &built_output.address(),
                         &csl::Value::new(&built_output.amount().coin()),
-                    )
+                    );
+                    if built_output.has_data_hash() {
+                        new_built_output.set_data_hash(&built_output.data_hash().unwrap());
+                    }
+                    if built_output.has_plutus_data() {
+                        new_built_output.set_plutus_data(&built_output.plutus_data().unwrap());
+                    }
+                    if built_output.has_script_ref() {
+                        new_built_output.set_script_ref(&built_output.script_ref().unwrap());
+                    }
+                    built_output = new_built_output;
                 }
             }
             None => {}

--- a/packages/whisky-examples/Cargo.toml
+++ b/packages/whisky-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisky-examples"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "The Cardano Rust SDK, inspired by MeshJS"
@@ -13,4 +13,4 @@ path = "src/server.rs"
 actix-cors = "0.7.0"
 actix-web = "4.9.0"
 serde = "1.0.209"
-whisky = { version = "=0.9.13", path = "../whisky" }
+whisky = { version = "=0.9.14", path = "../whisky" }

--- a/packages/whisky/Cargo.toml
+++ b/packages/whisky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisky"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "The Cardano Rust SDK, inspired by MeshJS"
@@ -24,7 +24,7 @@ pallas-codec = { version = "0.30.2", features = ["num-bigint"] }
 pallas-primitives = "0.31.0"
 pallas-traverse = "0.31.0"
 maestro-rust-sdk = "1.1.3"
-sidan-csl-rs = { version = "=0.9.13", path = "../sidan-csl-rs" }
+sidan-csl-rs = { version = "=0.9.14", path = "../sidan-csl-rs" }
 reqwest = "0.12.5"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 

--- a/packages/whisky/tests/integration_tests.rs
+++ b/packages/whisky/tests/integration_tests.rs
@@ -729,4 +729,37 @@ mod int_tests {
         println!("{}", signed_tx);
         assert!(mesh.core.mesh_csl.tx_hex != *"");
     }
+
+    #[test]
+    fn test_min_output_with_datum() {
+        let mut mesh = TxBuilder::new(TxBuilderParam {
+            evaluator: None,
+            fetcher: None,
+            submitter: None,
+            params: None,
+        });
+        let signed_tx = mesh
+            .tx_in(
+                "2cb57168ee66b68bd04a0d595060b546edf30c04ae1031b883c9ac797967dd85",
+                3,
+                &[Asset::new_from_str("lovelace", "9891607895")],
+                "addr_test1vru4e2un2tq50q4rv6qzk7t8w34gjdtw3y2uzuqxzj0ldrqqactxh",
+            )
+            .tx_out(
+                "addr_test1vru4e2un2tq50q4rv6qzk7t8w34gjdtw3y2uzuqxzj0ldrqqactxh",
+                &[]
+            )
+            .tx_out_inline_datum_value(&WData::JSON(json!({
+                "constructor": 0,
+                "fields": []
+            }).to_string()))
+            .change_address("addr_test1vru4e2un2tq50q4rv6qzk7t8w34gjdtw3y2uzuqxzj0ldrqqactxh")
+            .signing_key("51022b7e38be01d1cc581230e18030e6e1a3e949a1fdd2aeae5f5412154fe82b")
+            .complete_sync(None)
+            .unwrap()
+            .complete_signing().unwrap();
+
+        println!("{}", signed_tx);
+        assert!(mesh.core.mesh_csl.tx_hex != *"");
+    }
 }


### PR DESCRIPTION
## Summary

There was a bug when creating outputs with minimum value, the issue is that CSL did not equate an empty multiasset map with null. Which meant I had to rebuild the TransactionOutput with a null multiasset map instead. But during this process, the TransactionOutput was not created with the other information 

## Type of Change

### Feature Change

> Type of feature change:
>
> 1. New feature - non-breaking change which adds functionality
> 2. Breaking change - fix or feature that would cause existing functionality to not work as expected

- [ ] Rust crate `whisky` - New feature
- [ ] Rust crate `whisky` - Breaking change
- [x] WASM `sidan-csl-rs` - New feature
- [ ] WASM `sidan-csl-rs` - Breaking change

### Maintenance

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass
- [x] Both rust and wasm build pass
