### PR TITLE
return js error for asset name decoding

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -2830,7 +2830,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidan-csl-rs"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cardano-serialization-lib 13.2.0",
  "cryptoxide",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "whisky"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cryptoxide",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "whisky-examples"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-version = "0.9.16"
+version = "0.9.17"
 resolver = "2"
 members = [
     "sidan-csl-rs",

--- a/packages/sidan-csl-rs/Cargo.toml
+++ b/packages/sidan-csl-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidan-csl-rs"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wrapper around the cardano-serialization-lib for easier transaction building, heavily inspired by cardano-cli APIs"

--- a/packages/sidan-csl-rs/src/core/common/parser.rs
+++ b/packages/sidan-csl-rs/src/core/common/parser.rs
@@ -1,3 +1,4 @@
+use cardano_serialization_lib::JsError;
 use hex;
 
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
@@ -12,7 +13,10 @@ pub fn string_to_hex(s: &str) -> String {
     hex::encode(s)
 }
 
-pub fn hex_to_string(hex: &str) -> Result<String, std::str::Utf8Error> {
-    let bytes = hex::decode(hex).unwrap();
-    Ok(std::str::from_utf8(&bytes)?.to_string())
+pub fn hex_to_string(hex: &str) -> Result<String, JsError> {
+    let bytes = hex::decode(hex)
+        .map_err(|err| JsError::from_str(&format!("Invalid hex string found: {}", err)))?;
+    Ok(std::str::from_utf8(&bytes)
+        .map_err(|err| JsError::from_str(&format!("Invalid bytes for utf-8 found: {}", err)))?
+        .to_string())
 }

--- a/packages/sidan-csl-rs/src/core/core_csl.rs
+++ b/packages/sidan-csl-rs/src/core/core_csl.rs
@@ -353,7 +353,9 @@ impl MeshCSL {
         let mint_script = to_csl_script_source(script_source_info)?;
         mint_builder.add_asset(
             &csl::MintWitness::new_plutus_script(&mint_script, &mint_redeemer),
-            &csl::AssetName::new(hex::decode(script_mint.mint.asset_name).unwrap())?,
+            &csl::AssetName::new(hex::decode(script_mint.mint.asset_name).map_err(|err| {
+                JsError::from_str(&format!("Invalid asset name found: {}", err))
+            })?)?,
             &csl::Int::from_str(&script_mint.mint.amount.to_string()).unwrap(),
         )?;
         Ok(())
@@ -370,7 +372,9 @@ impl MeshCSL {
                 &csl::MintWitness::new_native_script(&csl::NativeScriptSource::new(
                     &csl::NativeScript::from_hex(&script.script_cbor)?,
                 )),
-                &csl::AssetName::new(hex::decode(native_mint.mint.asset_name).unwrap())?,
+                &csl::AssetName::new(hex::decode(native_mint.mint.asset_name).map_err(|err| {
+                    JsError::from_str(&format!("Invalid asset name found: {}", err))
+                })?)?,
                 &csl::Int::from_str(&native_mint.mint.amount.to_string()).unwrap(),
             )?,
             SimpleScriptSource::InlineSimpleScriptSource(script) => mint_builder.add_asset(
@@ -382,7 +386,9 @@ impl MeshCSL {
                     ),
                     script.script_size,
                 )),
-                &csl::AssetName::new(hex::decode(native_mint.mint.asset_name).unwrap())?,
+                &csl::AssetName::new(hex::decode(native_mint.mint.asset_name).map_err(|err| {
+                    JsError::from_str(&format!("Invalid asset name found: {}", err))
+                })?)?,
                 &csl::Int::from_str(&native_mint.mint.amount.to_string()).unwrap(),
             )?,
         };

--- a/packages/sidan-csl-rs/src/core/core_csl.rs
+++ b/packages/sidan-csl-rs/src/core/core_csl.rs
@@ -37,7 +37,7 @@ impl MeshCSL {
                 &csl::TransactionHash::from_hex(&input.tx_in.tx_hash)?,
                 input.tx_in.tx_index,
             ),
-            &to_value(&input.tx_in.amount.unwrap()),
+            &to_value(&input.tx_in.amount.unwrap())?,
         )?;
         Ok(())
     }
@@ -53,7 +53,7 @@ impl MeshCSL {
                         &csl::TransactionHash::from_hex(&input.tx_in.tx_hash)?,
                         input.tx_in.tx_index,
                     ),
-                    &to_value(&input.tx_in.amount.unwrap()),
+                    &to_value(&input.tx_in.amount.unwrap())?,
                 );
                 Ok(())
             }
@@ -71,7 +71,7 @@ impl MeshCSL {
                         &csl::TransactionHash::from_hex(&input.tx_in.tx_hash)?,
                         input.tx_in.tx_index,
                     ),
-                    &to_value(&input.tx_in.amount.unwrap()),
+                    &to_value(&input.tx_in.amount.unwrap())?,
                 );
                 Ok(())
             }
@@ -122,7 +122,7 @@ impl MeshCSL {
                 &csl::TransactionHash::from_hex(&input.tx_in.tx_hash)?,
                 input.tx_in.tx_index,
             ),
-            &to_value(&input.tx_in.amount.unwrap()),
+            &to_value(&input.tx_in.amount.unwrap())?,
         );
         Ok(())
     }
@@ -185,7 +185,7 @@ impl MeshCSL {
             }
         }
 
-        let tx_value = to_value(&output.amount);
+        let tx_value = to_value(&output.amount)?;
         let amount_builder = output_builder.next()?;
         let mut built_output: csl::TransactionOutput = if tx_value.multiasset().is_some() {
             if tx_value.coin().is_zero() {
@@ -238,7 +238,7 @@ impl MeshCSL {
                 &csl::TransactionHash::from_hex(&collateral.tx_in.tx_hash)?,
                 collateral.tx_in.tx_index,
             ),
-            &to_value(&collateral.tx_in.amount.unwrap()),
+            &to_value(&collateral.tx_in.amount.unwrap())?,
         )?;
         Ok(())
     }

--- a/packages/sidan-csl-rs/src/core/utils/value.rs
+++ b/packages/sidan-csl-rs/src/core/utils/value.rs
@@ -46,7 +46,7 @@ pub fn get_min_utxo_value(output: &Output, coins_per_utxo_size: &u64) -> Result<
             }
         }
     }
-    let multi_asset = match to_value(&output.amount).multiasset() {
+    let multi_asset = match to_value(&output.amount)?.multiasset() {
         Some(multi_asset) => multi_asset,
         None => csl::MultiAsset::new(),
     };

--- a/packages/whisky-examples/Cargo.toml
+++ b/packages/whisky-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisky-examples"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 license = "Apache-2.0"
 description = "The Cardano Rust SDK, inspired by MeshJS"
@@ -13,4 +13,4 @@ path = "src/server.rs"
 actix-cors = "0.7.0"
 actix-web = "4.9.0"
 serde = "1.0.209"
-whisky = { version = "=0.9.16", path = "../whisky" }
+whisky = { version = "=0.9.17", path = "../whisky" }

--- a/packages/whisky/Cargo.toml
+++ b/packages/whisky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisky"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 license = "Apache-2.0"
 description = "The Cardano Rust SDK, inspired by MeshJS"
@@ -24,7 +24,7 @@ pallas-codec = { version = "0.30.2", features = ["num-bigint"] }
 pallas-primitives = "0.31.0"
 pallas-traverse = "0.31.0"
 maestro-rust-sdk = "1.1.3"
-sidan-csl-rs = { version = "=0.9.16", path = "../sidan-csl-rs" }
+sidan-csl-rs = { version = "0.9.17", path = "../sidan-csl-rs" }
 reqwest = "0.12.5"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 


### PR DESCRIPTION
## Summary

Hex decoding asset names uses unwrap so doesn't return any error to wasm side. Map errors to return JsError.

## Type of Change

> Please mark the relevant option(s) for your pull request:

### Feature Change

> Type of feature change:
>
> 1. New feature - non-breaking change which adds functionality
> 2. Breaking change - fix or feature that would cause existing functionality to not work as expected

- [ ] Rust crate `whisky` - New feature
- [ ] Rust crate `whisky` - Breaking change
- [x] WASM `sidan-csl-rs` - New feature
- [ ] WASM `sidan-csl-rs` - Breaking change

### Maintenance

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass
- [x] Both rust and wasm build pass

