### PR TITLE
feat: add derivation indices from str

### DIFF
--- a/packages/whisky-wallet/src/wallet/derivation_indices.rs
+++ b/packages/whisky-wallet/src/wallet/derivation_indices.rs
@@ -50,14 +50,14 @@ impl DerivationIndices {
         let derivation_path_vec_u32: Vec<u32> = derivation_path_vec
             .iter()
             .skip(1)
-            .filter_map(|&s| {
+            .map(|&s| {
                 if s.ends_with("'") {
                     // Remove the last character (')
                     let path_str = s.strip_suffix("'").unwrap();
                     // Parse the string to u32 and add 0x80000000 for hardening
-                    Some(path_str.parse::<u32>().unwrap() + 0x80000000)
+                    path_str.parse::<u32>().unwrap() + 0x80000000
                 } else {
-                    s.parse::<u32>().ok()
+                    s.parse::<u32>().unwrap()
                 }
             })
             .collect();

--- a/packages/whisky-wallet/src/wallet/derivation_indices.rs
+++ b/packages/whisky-wallet/src/wallet/derivation_indices.rs
@@ -44,4 +44,23 @@ impl DerivationIndices {
             key_index,                          // key index
         ])
     }
+
+    pub fn from_str(derivation_path_str: &str) -> Self {
+        let derivation_path_vec: Vec<&str> = derivation_path_str.split('/').collect();
+        let derivation_path_vec_u32: Vec<u32> = derivation_path_vec
+            .iter()
+            .skip(1)
+            .filter_map(|&s| {
+                if s.ends_with("'") {
+                    // Remove the last character (')
+                    let path_str = s.strip_suffix("'").unwrap();
+                    // Parse the string to u32 and add 0x80000000 for hardening
+                    Some(path_str.parse::<u32>().unwrap() + 0x80000000)
+                } else {
+                    s.parse::<u32>().ok()
+                }
+            })
+            .collect();
+        DerivationIndices(derivation_path_vec_u32)
+    }
 }

--- a/packages/whisky-wallet/tests/wallet/bip39.rs
+++ b/packages/whisky-wallet/tests/wallet/bip39.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod test {
-    use whisky_wallet::Wallet;
+    use whisky_wallet::{
+        derivation_indices::DerivationIndices, MnemonicWallet, Wallet, WalletType,
+    };
 
     #[test]
     fn test_mnemonic_sign_tx() {
@@ -26,5 +28,21 @@ mod test {
         signed_tx,
         "84a4008182582004509185eb98edd8e2420c1ceea914d6a7a3142041039b2f12b4d4f03162d56f04018282581d605867c3b8e27840f556ac268b781578b14c5661fc63ee720dbeab663f1a000f42408258390004845038ee499ee8bc0afe56f688f27b2dd76f230d3698a9afcc1b66e0464447c1f51adaefe1ebfb0dd485a349a70479ced1d198cbdf7fe71a15d35396021a0002917d075820bdaa99eb158414dea0a91d6c727e2268574b23efe6e08ab3b841abe8059a030ca10081825820c32dfdb461dd016e8fdd9b6d424a77439eab8f8c644a804b013b6cefa2454f9558402bfcad51fc81ecf7bd2e0fb3dbda51630d9457353e30f8cc04e12737d2753ec712148e34f78d5633ceb99e004534cc22216b265bc308a1f154952eaf72ae2e0df5d90103a0"
     );
+    }
+
+    #[test]
+    fn test_raw_path_sign_tx() {
+        let wallet = Wallet::new(
+            WalletType::MnemonicWallet(MnemonicWallet {
+                mnemonic_phrase: "summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer summer".to_string(),
+                derivation_indices: DerivationIndices::from_str("m/1852'/1815'/0'/0/0"),
+            })
+        );
+        let tx_hex = "84a4008182582004509185eb98edd8e2420c1ceea914d6a7a3142041039b2f12b4d4f03162d56f04018282581d605867c3b8e27840f556ac268b781578b14c5661fc63ee720dbeab663f1a000f42408258390004845038ee499ee8bc0afe56f688f27b2dd76f230d3698a9afcc1b66e0464447c1f51adaefe1ebfb0dd485a349a70479ced1d198cbdf7fe71a15d35396021a0002917d075820bdaa99eb158414dea0a91d6c727e2268574b23efe6e08ab3b841abe8059a030ca0f5d90103a0";
+        let signed_tx = wallet.sign_tx(tx_hex).unwrap();
+        assert_eq!(
+            signed_tx,
+            "84a4008182582004509185eb98edd8e2420c1ceea914d6a7a3142041039b2f12b4d4f03162d56f04018282581d605867c3b8e27840f556ac268b781578b14c5661fc63ee720dbeab663f1a000f42408258390004845038ee499ee8bc0afe56f688f27b2dd76f230d3698a9afcc1b66e0464447c1f51adaefe1ebfb0dd485a349a70479ced1d198cbdf7fe71a15d35396021a0002917d075820bdaa99eb158414dea0a91d6c727e2268574b23efe6e08ab3b841abe8059a030ca1008182582089f4b576f05f5aad99bce0bdd51afe48529772f7561bb2ac9d84a4afbda1ecd658404cd1466fcc4579fa9c89656dbbd25ca659cccf2d2783417ef13a1b060bf836fbe8383c10e25c6fa323c1c81a0799e87e6cf3eaa25990113b27953a9836635a01f5d90103a0"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adding an option to create derivation keys from a BIP32 derivation path string, for example "m/44'/0'/0'/0/0"

## Scope of Change

- [ ] `whisky`
- [ ] `whisky-provider`
- [x] `whisky-wallet`
- [ ] `whisky-csl`
- [ ] `whisky-common`
- [ ] `whisky-js`


## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass
- [x] Both rust and wasm build pass
