### PR TITLE
fix: withdrawal_tx_in_reference missing asign withdrawal_item

### DIFF
--- a/packages/whisky/src/builder/withdrawal.rs
+++ b/packages/whisky/src/builder/withdrawal.rs
@@ -99,7 +99,8 @@ impl TxBuilder {
                         simple_script_hash: withdrawal_script_hash.to_string(),
                         script_size,
                     },
-                ))
+                ));
+                self.withdrawal_item = Some(Withdrawal::SimpleScriptWithdrawal(withdrawal));
             }
             Withdrawal::PlutusScriptWithdrawal(mut withdrawal) => {
                 withdrawal.script_source =


### PR DESCRIPTION
## Summary
In builder withdrawal api case `PlutusScriptWithdrawal` missing assign back to `withdrawal_item`

## Scope of Change

- [X] `whisky`
- [ ] `whisky-provider`
- [ ] `whisky-wallet`
- [ ] `whisky-csl`
- [ ] `whisky-common`
- [ ] `whisky-js`

## Type of Change

> Please mark the relevant option(s) for your pull request:

### Feature Change

> Type of feature change:
> 1. New feature - non-breaking change which adds functionality

### Maintenance

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

- [X] My code is appropriately commented and includes relevant documentation, if necessary
- [X] I have added tests to cover my changes, if necessary
- [X] I have updated the documentation, if necessary
- [X] All new and existing tests pass
- [X] Both rust and wasm build pass
